### PR TITLE
Handle case where Dyn returns an empty CSV

### DIFF
--- a/src/dyn.go
+++ b/src/dyn.go
@@ -143,6 +143,11 @@ func (p DynProvider) getQpsReport() (qpsForZone map[string]float64, err error) {
 		return qpsForZone, err
 	}
 
+	if len(raw) == 0 {
+		err = errors.New("No QPS data received")
+		return
+	}
+
 	// Return the most recent complete-period set of metrics (second last)
 	qpsForZone = extractSecondLastQps(raw)
 	return

--- a/src/dyn_test.go
+++ b/src/dyn_test.go
@@ -50,9 +50,7 @@ func TestParseQpsCsv(t *testing.T) {
 	out, err := parseQpsCsv(input)
 	if err != nil {
 		t.Error("Received error from parseQpsCsv ", err)
-	} else {
-		if !reflect.DeepEqual(out, expected) {
-			t.Error("Output of parseQpsCsv does not match expectations")
-		}
+	} else if !reflect.DeepEqual(out, expected) {
+		t.Error("Output of parseQpsCsv does not match expectations")
 	}
 }


### PR DESCRIPTION
Dyn had a bug in its QPS-reporting code which was resulting in returning
a CSV file with no data (only header). Trying to extractSecondLastQps
on that data led to a panic trying to access `raw[keys[len(keys)-2]]`
on a nil map.

I was torn as to whether to put the error checking in getQpsReport()
or in extractSecondLastQps and am happy to accept feedback :-)