### PR TITLE
Handle insufficient QPS data from Dyn (and increase chances of getting sufficient data)

### DIFF
--- a/src/dyn.go
+++ b/src/dyn.go
@@ -142,9 +142,10 @@ func (p DynProvider) getQpsReport() (qpsForZone map[string]float64, err error) {
 	if err != nil {
 		return qpsForZone, err
 	}
+	log.Debug("Zone QPS file contained ", len(raw), " periods:\n", q.Data.Csv)
 
-	if len(raw) == 0 {
-		err = errors.New("No QPS data received")
+	if len(raw) < 2 {
+		err = errors.New(fmt.Sprintf("Not enough QPS data received (need 2 periods, got %d)", len(raw)))
 		return
 	}
 

--- a/src/dyn.go
+++ b/src/dyn.go
@@ -128,7 +128,7 @@ func (p DynProvider) getQpsReport() (qpsForZone map[string]float64, err error) {
 
 	// Fetch metrics from the API
 	args := map[string]string{
-		"start_ts":  strconv.FormatInt(time.Now().Unix()-15*60, 10),
+		"start_ts":  strconv.FormatInt(time.Now().Unix()-20*60, 10),
 		"end_ts":    strconv.FormatInt(time.Now().Unix(), 10),
 		"breakdown": "zones",
 	}


### PR DESCRIPTION
We require at least two periods of data from Dyn's `QPSReport` endpoint in order to have (and report on) a completed period (two periods = a full period + the current incomplete period).

Despite asking for 15 minutes worth of every-5-minutes data, Dyn's `QPSReport` endpoint sometimes only returns the current period.

I've opened a support ticket, but in the meantime, this PR contains two changes to deal with that issue:
* it prevents a panic in `extractSecondLastQps` when the data contains <2 periods, allowing the rest of the metrics to report
* it increases the odds of us getting 2 or more periods, by asking Dyn for 20 minutes of data, not 15

