### PR TITLE
Move to a PD-standard base image in CI processes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-# See also https://circleci.com/docs/2.0/language-go/ 
+# See also https://circleci.com/docs/2.0/language-go/
 version: 2
 jobs:
   build:
@@ -7,4 +7,4 @@ jobs:
     working_directory: /go/src/github.com/PagerDuty/dnsmetrics
     steps:
       - checkout
-      - run: make
+      - run: make DOCKER_FILE=Dockerfile.internal

--- a/Dockerfile.internal
+++ b/Dockerfile.internal
@@ -1,8 +1,8 @@
-FROM bitnami/minideb:stretch
+FROM pagerduty-docker.jfrog.io/ubuntu:18.04
 
 RUN apt-get update && \
-    apt-get upgrade -y && \
-    install_packages ca-certificates
+    apt-get -y install ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY dnsmetrics /usr/bin/dnsmetrics
 

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ SOURCES := $(shell find $(SOURCEDIR) -name '*.go')
 
 DOCKER_TAG := $(shell bash build/determine_docker_tag.sh)
 DOCKER_NAME = pagerduty-docker.jfrog.io/$(APP):$(DOCKER_TAG)
+DOCKER_FILE ?= Dockerfile
 
 OS := $(shell uname)
 
@@ -31,7 +32,7 @@ ifneq ($(OS),Linux)
 	GOOS=linux GOARCH=amd64 go build -o ${APP} ${SOURCES}
 endif
 ifneq ($(strip $(DOCKER_TAG)),)
-	docker build -t ${DOCKER_NAME} .
+	docker build -f ${DOCKER_FILE} -t ${DOCKER_NAME} .
 ifneq (${DOCKER_USERNAME},)
 ifneq (${DOCKER_PASSWORD},)
 	docker login -u ${DOCKER_USERNAME} -p "${DOCKER_PASSWORD}"


### PR DESCRIPTION
Keep the public Dockerfile available and default; our CI process
will use a different base image to comply with company policies.

Also included:
- In public image, move to stretch from jessie
- In private image: no need to upgrade packages, base image is kept up to date
- In private image: Clean up apt state after installing to minimize image size